### PR TITLE
fixed: added current order view to confirmation page with a gif

### DIFF
--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -55,7 +55,7 @@ export default class Main extends Component {
                 render = {() => <Home searchValue={this.state.searchValue} />}
             />
             <Route path="/checkout" component={OrderCheckout} />
-            <Route path="/confirmation" component={OrderConfirmation} />
+            <Route path="/confirmation/:orderId" component={OrderConfirmation} />
             <Route path="/login" component={Login} />
             <Route path="/signup" component={Signup} />
             <Route path="/cart" component={Cart} />

--- a/client/components/OrderCheckout.jsx
+++ b/client/components/OrderCheckout.jsx
@@ -5,6 +5,7 @@ import {withRouter} from 'react-router'
 import { addUser } from '../reducers/users'
 import {addAddressToOrder, clearCart} from '../reducers/cart'
 import {addCartId} from '../reducers/cartId'
+import SingleOrder from './SingleOrder'
 import store from '../store'
 
 
@@ -55,11 +56,11 @@ class OrderCheckout extends Component {
 }
 
 const mapStateToProps = (state) => {
-    return {
-        users: state.users,
-        currentUser: state.currentUser,
-        cartId: state.cartId
-    }
+  return {
+      users: state.users,
+      currentUser: state.currentUser,
+      cartId: state.cartId,
+  }
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
@@ -69,7 +70,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           const emailAddress = evt.target.email.value
           const shippingAddress = evt.target.shippingAddress.value
           dispatch(addAddressToOrder(cartId, shippingAddress, emailAddress))
-          ownProps.history.push('/confirmation')
+          ownProps.history.push(`/confirmation/${cartId}`)
         },
         removeSessionCart: function() {
 

--- a/client/components/OrderConfirmation.jsx
+++ b/client/components/OrderConfirmation.jsx
@@ -5,6 +5,7 @@ import {withRouter} from 'react-router'
 import { addUser } from '../reducers/users'
 import {addAddressToOrder, clearCart} from '../reducers/cart'
 import {addCartId} from '../reducers/cartId'
+import SingleOrder from './SingleOrder'
 import store from '../store'
 
 
@@ -13,12 +14,21 @@ export default class OrderCheckout extends Component {
     super(props)
   }
 
+  componentDidMount() {
+    store.dispatch(addCartId())
+  }
+
   render () {
     return (
       <div>
-        <h1>Your order is being processed...</h1>
-        <p> render the single order component here from Raz</p>
-        <p> <NavLink to="/">Click to go back to main page</NavLink></p>
+        <div className="banner">
+          <img className="mascot" src="/img/cat-banner.gif" />
+          <p>Your order has been placed!</p>
+        </div>
+        <p>Your tabby cat thanks you ...</p>
+          <SingleOrder />
+        <p> <NavLink to="/">Are you sure your tabby cat doesn't want more?</NavLink></p>
+
       </div>
     )
   }

--- a/client/components/SingleOrder.jsx
+++ b/client/components/SingleOrder.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import {withRouter} from 'react-router'
 import OrderAccessory from './OrderAccessory'
 
-function SingleOrder(props){
+export function SingleOrder(props){
   const { orderAccs } = props
   const order = orderAccs.length ? orderAccs[0].order: {}
   let total = 0;


### PR DESCRIPTION
There is order checkout page with email and shipping address, and then order confirmation loads the current order along with confirmation